### PR TITLE
Change module target to es2019

### DIFF
--- a/config/tsconfig.module.json
+++ b/config/tsconfig.module.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig",
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2019",
     "outDir": "../build/module",
     "module": "esnext"
   },


### PR DESCRIPTION
This is a stopgap fix for #52. Create react app and several other contexts don't support libauth because they don't support the nullish coalescing (`??`) operator. This PR changes the TypeScript output from `esnext` to `es2019`, which does not include the nullish coalescing operator. This should allow these outdated tools to work with libauth.