### PR TITLE
Mark the repository as side-effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,5 +203,6 @@
       "**/*.spec.helper.js",
       "**/*.spec.debug.js"
     ]
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
Hey! We've been working on reducing our bundle size with webpack, and libauth is still a large part of the resulting bundle. According to the [Webpack docs](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) all packages in the tree need to have a `"sideEffects"` property set in their package.json to be tree-shaken with webpack. 

This PR adds that property to libauth. It tells webpack that none of the files in libauth contain *any* side-effects (e.g. changing the global scope). This allows webpack to safely tree-shake any unused code.