### PR TITLE
Make bigIntToBinUint64LE compatible with Safari (fixes #69)

### DIFF
--- a/src/lib/format/numbers.ts
+++ b/src/lib/format/numbers.ts
@@ -180,13 +180,10 @@ export const bigIntToBinUint64LEClamped = (value: bigint) => {
  * @param value - the number to encode
  */
 export const bigIntToBinUint64LE = (value: bigint) => {
-  const uint64Length = 8;
-  const bin = new Uint8Array(uint64Length);
-  const writeAsLittleEndian = true;
-  const view = new DataView(bin.buffer, bin.byteOffset, bin.byteLength);
-  // eslint-disable-next-line functional/no-expression-statement
-  view.setBigUint64(0, value, writeAsLittleEndian);
-  return bin;
+  const uint64LengthInBits = 64;
+  const valueAsUint64 = BigInt.asUintN(uint64LengthInBits, value);
+  const fixedLengthBin = bigIntToBinUint64LEClamped(valueAsUint64);
+  return fixedLengthBin;
 };
 
 /**


### PR DESCRIPTION
This uses a different method to get the same results. Tests are still passing indicating that over- and underflows are also handled the same as before. This does not use DataView.prototype.setBigUint64, which was incompatible with Safari.