### PR TITLE
Make binToBigIntUint64LE() Safari-compatible

### DIFF
--- a/src/lib/format/numbers.spec.ts
+++ b/src/lib/format/numbers.spec.ts
@@ -416,17 +416,34 @@ test('binToBigIntUint64LE', (t) => {
     BigInt(0x12345678)
   );
   t.deepEqual(
-    binToBigIntUint64LE(Uint8Array.from([0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01])),
+    binToBigIntUint64LE(
+      Uint8Array.from([0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01])
+    ),
     BigInt('0x0123456789abcdef')
   );
   t.deepEqual(
-    binToBigIntUint64LE(Uint8Array.from([0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, 0x00, 0x00])),
+    binToBigIntUint64LE(
+      Uint8Array.from([
+        0xef,
+        0xcd,
+        0xab,
+        0x89,
+        0x67,
+        0x45,
+        0x23,
+        0x01,
+        0x00,
+        0x00,
+      ])
+    ),
     BigInt('0x0123456789abcdef')
   );
   const data = Uint8Array.from([0x90, 0x78, 0x56, 0x34, 0x12, 0, 0, 0, 0, 0]);
   const view = data.subarray(2);
   t.deepEqual(binToBigIntUint64LE(view), BigInt(0x123456));
-  t.throws(() => binToBigIntUint64LE(Uint8Array.from([0x78, 0x56, 0x34, 0x12])))
+  t.throws(() =>
+    binToBigIntUint64LE(Uint8Array.from([0x78, 0x56, 0x34, 0x12]))
+  );
 });
 
 test('readBitcoinVarInt: offset is optional', (t) => {

--- a/src/lib/format/numbers.spec.ts
+++ b/src/lib/format/numbers.spec.ts
@@ -415,9 +415,18 @@ test('binToBigIntUint64LE', (t) => {
     binToBigIntUint64LE(Uint8Array.from([0x78, 0x56, 0x34, 0x12, 0, 0, 0, 0])),
     BigInt(0x12345678)
   );
+  t.deepEqual(
+    binToBigIntUint64LE(Uint8Array.from([0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01])),
+    BigInt('0x0123456789abcdef')
+  );
+  t.deepEqual(
+    binToBigIntUint64LE(Uint8Array.from([0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, 0x00, 0x00])),
+    BigInt('0x0123456789abcdef')
+  );
   const data = Uint8Array.from([0x90, 0x78, 0x56, 0x34, 0x12, 0, 0, 0, 0, 0]);
   const view = data.subarray(2);
   t.deepEqual(binToBigIntUint64LE(view), BigInt(0x123456));
+  t.throws(() => binToBigIntUint64LE(Uint8Array.from([0x78, 0x56, 0x34, 0x12])))
 });
 
 test('readBitcoinVarInt: offset is optional', (t) => {

--- a/src/lib/format/numbers.ts
+++ b/src/lib/format/numbers.ts
@@ -421,9 +421,11 @@ export const binToBigIntUintLE = (bin: Uint8Array, bytes = bin.length) => {
  * @param bin - the Uint8Array to decode
  */
 export const binToBigIntUint64LE = (bin: Uint8Array) => {
-  const view = new DataView(bin.buffer, bin.byteOffset, bin.byteLength);
-  const readAsLittleEndian = true;
-  return view.getBigUint64(0, readAsLittleEndian);
+  const uint64LengthInBytes = 8;
+  const truncatedBin = bin.length > uint64LengthInBytes
+    ? bin.slice(0, uint64LengthInBytes)
+    : bin;
+  return binToBigIntUintLE(truncatedBin, uint64LengthInBytes);
 };
 
 const enum VarInt {

--- a/src/lib/format/numbers.ts
+++ b/src/lib/format/numbers.ts
@@ -422,9 +422,8 @@ export const binToBigIntUintLE = (bin: Uint8Array, bytes = bin.length) => {
  */
 export const binToBigIntUint64LE = (bin: Uint8Array) => {
   const uint64LengthInBytes = 8;
-  const truncatedBin = bin.length > uint64LengthInBytes
-    ? bin.slice(0, uint64LengthInBytes)
-    : bin;
+  const truncatedBin =
+    bin.length > uint64LengthInBytes ? bin.slice(0, uint64LengthInBytes) : bin;
   return binToBigIntUintLE(truncatedBin, uint64LengthInBytes);
 };
 


### PR DESCRIPTION
Hey @bitjson, in PR #70 I made bigIntToBinUint64LE() compatible with Safari, but we found out that we missed binToBigIntUint64LE(), which is currently not compatible with Safari. This PR changes the implementation (while keeping the same behaviour) so that it is compatible with Safari. It also adds a few extra tests for this function.