### PR TITLE
Add token info to input and output generation routines

### DIFF
--- a/src/lib/message/transaction-types.ts
+++ b/src/lib/message/transaction-types.ts
@@ -330,8 +330,8 @@ export interface CompilationDirectiveUnlocking<
   valueSatoshis: Output['valueSatoshis'];
 
   /**
-   * The CashToken contents of this output. This property is only defined if the
-   * output contains one or more tokens. For details, see
+   * The CashToken contents of this input. This property is only defined if the
+   * input contains one or more tokens. For details, see
    * `CHIP-2022-02-CashTokens`.
    */
   token?: Output['token'];

--- a/src/lib/message/transaction-types.ts
+++ b/src/lib/message/transaction-types.ts
@@ -328,6 +328,13 @@ export interface CompilationDirectiveUnlocking<
    * Required for use in signing serializations.
    */
   valueSatoshis: Output['valueSatoshis'];
+
+  /**
+   * The CashToken contents of this output. This property is only defined if the
+   * output contains one or more tokens. For details, see
+   * `CHIP-2022-02-CashTokens`.
+   */
+  token?: Output['token'];
 }
 
 export interface CompilationDirectiveUnlockingEstimate<

--- a/src/lib/transaction/generate-transaction.ts
+++ b/src/lib/transaction/generate-transaction.ts
@@ -73,12 +73,14 @@ export const compileOutputTemplate = <
       ? {
           lockingBytecode: result.bytecode,
           valueSatoshis: outputTemplate.valueSatoshis,
+          token: outputTemplate.token,
         }
       : returnFailedCompilationDirective({ index, result, type: 'locking' });
   }
   return {
     lockingBytecode: outputTemplate.lockingBytecode.slice(),
     valueSatoshis: outputTemplate.valueSatoshis,
+    token: outputTemplate.token,
   };
 };
 
@@ -108,6 +110,7 @@ export const compileInputTemplate = <
     sourceOutputs[index] = {
       lockingBytecode: Uint8Array.of(),
       valueSatoshis: inputTemplate.unlockingBytecode.valueSatoshis,
+      token: inputTemplate.unlockingBytecode.token,
     };
     const result = directive.compiler.generateBytecode({
       data: {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix, token data was not respected in transaction generation.

* **What is the current behavior?** (You can also link to an open issue here)

Transactions are not built to contain valid token outputs. Transaction spending token utxos not signed with SIGHASH_UTXOS

* **What is the new behavior (if this is a feature change)?**

Token data is included in transaction building pipeline, inputs are signed with SIGHASH_UTXOS

* **Other information**:

Closes #102 